### PR TITLE
restore the warning highlighting for allergies on antiseptics

### DIFF
--- a/assets/css/module.css
+++ b/assets/css/module.css
@@ -22,11 +22,23 @@
 }
 /* line 19, ../sass/components/_event.scss */
 .event .event-content {
-  background-image: url('../img/watermark.png?1392372886');
+  background-image: url('../img/watermark.png?1449572440');
 }
 /* line 22, ../sass/components/_event.scss */
 .event .event-title {
-  background-image: url('../img/medium.png?1383822664');
+  background-image: url('../img/medium.png?1449572440');
+}
+
+/* line 27, ../sass/components/_event.scss */
+.wrapper {
+  padding: 5px;
+  border-radius: 5px;
+  display: inline-block;
+}
+
+/* line 29, ../sass/components/_event.scss */
+.allergyWarning {
+  background-color: #f66 !important;
 }
 
 /* line 18, ../sass/components/_elements.scss */

--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -83,3 +83,14 @@
     margin: 10px 0;
   }
 }
+/* line 20, ../sass/print.scss */
+.metadata {
+  width: 100% !important;
+}
+
+/* line 24, ../sass/print.scss */
+.info {
+  width: 100% !important;
+  font-size: 9pt !important;
+  display: block !important;
+}

--- a/assets/sass/components/_event.scss
+++ b/assets/sass/components/_event.scss
@@ -23,3 +23,9 @@
 		background-image: image-url("medium.png");
 	}
 }
+
+.wrapper { padding: 5px; border-radius: 5px; display: inline-block; }
+
+.allergyWarning {
+	background-color: #f66 !important;
+}


### PR DESCRIPTION
For patients that are allergic to any of the antiseptic drugs, the selection should be highlighted with a warning colour. This change restores the CSS that is required for that behaviour
